### PR TITLE
Use max-width so textarea cannot be dragged outside of frame

### DIFF
--- a/web/assets/barometer/css/barometer_iframe.css
+++ b/web/assets/barometer/css/barometer_iframe.css
@@ -52,7 +52,7 @@ p {
 input, textarea {
 	padding:5px; 
 	font-size:14px; 
-	width:98%;
+	max-width:98%;
 	}
 
 input[type=text], textarea {


### PR DESCRIPTION
The user can expand the <textarea> outside of the frame.  Setting max-width avoids this issue.
